### PR TITLE
Calculating strokes gained for each shot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 Transforms raw shot-level data into strokes-gained analytics.
 
 ## Changelog
-Sept 29, 2021: Set up repository. Initiated dbt and connected to BigQuery.
-
-Oct 6, 2021: Added initial staging logic and testing to prepare raw data for analysis.
+- Sept 29, 2021: Set up repository. Initiated dbt and connected to BigQuery.
+- Oct 6, 2021: Added initial staging logic and testing to prepare raw data for analysis.
+- Oct 13, 2021: Added transformation logic to calculate strokes gained for each shot, additional schema testing, and custom test to check for data entry errors. Strokes gained data relative to PGA TOUR average is ready to be visualized!

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -20,6 +20,12 @@ require-dbt-version: ">=0.21.0"
 
 models:
   hit_bombs_attack_pins:
+    facts:
+      materialized: view
+      schema: fct
     staging:
       materialized: view
-      schema: staging
+      schema: stg
+    viz:
+      materialized: table
+      schema: viz

--- a/models/facts/fct_shots.sql
+++ b/models/facts/fct_shots.sql
@@ -1,0 +1,46 @@
+WITH shots AS (
+  SELECT
+    *
+  FROM {{ ref('stg_shots') }}
+),
+
+holes AS (
+  SELECT
+    *
+  FROM {{ ref('stg_holes') }}
+),
+
+shot_types AS (
+  SELECT
+    *
+  FROM {{ ref('stg_shot_types') }}
+),
+
+shots_joined AS (
+  SELECT
+    shots.shot_id,
+    shots.hole_shot_seq,
+    shot_types.shot_type_id,
+    shot_types.name AS shot_type,
+    shots.hole_id,
+    shots.measured_distance,
+    holes.scorecard_yardage AS hole_scorecard_yardage,
+    holes.satellite_yardage AS hole_satellite_yardage,
+    shots.round_id,
+    CASE
+      WHEN shots.measured_distance IS NOT NULL THEN shots.measured_distance
+      WHEN shots.measured_distance IS NULL
+        AND shot_types.name = 'Tee' THEN holes.satellite_yardage
+      WHEN shots.measured_distance IS NULL
+        AND holes.satellite_yardage IS NULL
+        AND shot_types.name = 'Tee' THEN holes.scorecard_yardage
+      ELSE NULL
+    END AS distance
+  FROM shots
+  JOIN shot_types ON shots.shot_type = shot_types.shot_type_id
+  LEFT JOIN holes ON shots.hole_id = holes.hole_id
+)
+
+SELECT
+  *
+FROM shots_joined

--- a/models/staging/staging_schema.yml
+++ b/models/staging/staging_schema.yml
@@ -69,9 +69,7 @@ models:
           - not_null
       - name: pro_strokes_to_hole
         tests:
-          - not_null:
-              config:
-                severity: warn
+          - not_null
       - name: shot_type
         tests:
           - not_null

--- a/models/viz/shots_strokes_gained.sql
+++ b/models/viz/shots_strokes_gained.sql
@@ -1,0 +1,53 @@
+WITH shots AS (
+  SELECT
+    *
+  FROM {{ ref('fct_shots') }}
+),
+
+shots_to_hole AS (
+  SELECT
+    *
+  FROM {{ ref('stg_shots_to_hole') }}
+),
+
+shots_with_avgs AS (
+  SELECT
+    shots.shot_id,
+    shots.hole_shot_seq,
+    shots.shot_type,
+    shots.hole_id,
+    shots.distance,
+    shots.round_id,
+    shots_to_hole.pro_strokes_to_hole,
+    shots_to_hole.scratch_strokes_to_hole
+  FROM shots
+  LEFT JOIN shots_to_hole ON shots.shot_type_id = shots_to_hole.shot_type
+    AND shots.distance = shots_to_hole.distance
+)
+
+SELECT
+  shot_id,
+  hole_shot_seq,
+  shot_type,
+  hole_id,
+  distance,
+  round_id,
+  pro_strokes_to_hole,
+  scratch_strokes_to_hole,
+
+  {% set fields = ['distance', 'shot_type', 'pro_strokes_to_hole', 'scratch_strokes_to_hole'] %}
+
+  {% for field in fields %}
+
+  LEAD({{ field }}) OVER(
+    PARTITION BY
+      hole_id,
+      round_id
+    ORDER BY
+      hole_shot_seq
+  ) AS resulting_{{ field }}
+
+  {% if not loop.last %} , {% endif %}
+
+  {% endfor %}
+FROM shots_with_avgs

--- a/models/viz/shots_strokes_gained.sql
+++ b/models/viz/shots_strokes_gained.sql
@@ -23,31 +23,58 @@ shots_with_avgs AS (
   FROM shots
   LEFT JOIN shots_to_hole ON shots.shot_type_id = shots_to_hole.shot_type
     AND shots.distance = shots_to_hole.distance
+),
+
+shots_with_results AS (
+  SELECT
+    shot_id,
+    hole_shot_seq,
+    shot_type,
+    hole_id,
+    distance,
+    round_id,
+    pro_strokes_to_hole,
+    scratch_strokes_to_hole,
+
+    {% set fields = ['distance', 'shot_type', 'pro_strokes_to_hole', 'scratch_strokes_to_hole'] %}
+
+    {% for field in fields %}
+
+    LEAD({{ field }}) OVER(
+      PARTITION BY
+        hole_id,
+        round_id
+      ORDER BY
+        hole_shot_seq
+    ) AS resulting_{{ field }},
+
+    LEAD({{ field }}, 2) OVER(
+      PARTITION BY
+        hole_id,
+        round_id
+      ORDER BY
+        hole_shot_seq
+    ) AS two_strokes_later_{{ field }}
+
+    {% if not loop.last %} , {% endif %}
+
+    {% endfor %}
+  FROM shots_with_avgs
 )
 
 SELECT
-  shot_id,
-  hole_shot_seq,
-  shot_type,
-  hole_id,
-  distance,
-  round_id,
-  pro_strokes_to_hole,
-  scratch_strokes_to_hole,
+  *,
+  {% set toggles = ['pro', 'scratch'] %}
 
-  {% set fields = ['distance', 'shot_type', 'pro_strokes_to_hole', 'scratch_strokes_to_hole'] %}
+  {% for toggle in toggles %}
 
-  {% for field in fields %}
-
-  LEAD({{ field }}) OVER(
-    PARTITION BY
-      hole_id,
-      round_id
-    ORDER BY
-      hole_shot_seq
-  ) AS resulting_{{ field }}
+  CASE
+    WHEN resulting_shot_type IS NULL THEN {{ toggle }}_strokes_to_hole - 1 -- if the stroke is holed, return the average strokes to hole from the previous position minus the shot required to hole out.
+    WHEN shot_type = 'Penalty' THEN 0 -- strokes lost due to penalty are applied to the shot preceding the penalty stroke.
+    WHEN resulting_shot_type = 'Penalty' THEN {{ toggle }}_strokes_to_hole - two_strokes_later_{{ toggle }}_strokes_to_hole - 2 -- if a stroke results in a penalty, use the average strokes to hole from the shot following the penalty.
+    ELSE {{ toggle }}_strokes_to_hole - resulting_{{ toggle }}_strokes_to_hole - 1
+  END AS strokes_gained_{{ toggle }}
 
   {% if not loop.last %} , {% endif %}
-
   {% endfor %}
-FROM shots_with_avgs
+FROM shots_with_results

--- a/models/viz/viz_schema.yml
+++ b/models/viz/viz_schema.yml
@@ -1,0 +1,13 @@
+version: 2
+
+models:
+  - name: shots_strokes_gained
+    description: A table at the level of a stroke, complete with information about that stroke and its strokes gained values.
+    columns:
+      - name: shot_id
+        tests:
+          - not_null
+          - unique
+      - name: strokes_gained_pro
+        tests:
+          - not_null

--- a/tests/data_entry/shot_sequence_check.sql
+++ b/tests/data_entry/shot_sequence_check.sql
@@ -1,0 +1,34 @@
+/*
+
+This test checks that each shot's row number matches its hole_shot_seq value.
+If the test fails, it means that a hole_shot_seq values probably got entered incorrectly.
+I found one entry where I accidentally entered in the wrong hole for a shot, so
+that may be worth checking as well if this test fails.
+*/
+
+WITH shots AS (
+  SELECT
+    *
+  FROM {{ ref('stg_shots') }}
+),
+
+shots_with_row_number AS (
+  SELECT
+    ROW_NUMBER() OVER(
+      PARTITION BY
+        hole_id,
+        round_id
+      ORDER BY
+        hole_shot_seq
+    ) AS rn,
+    hole_shot_seq,
+    shot_id,
+    hole_id,
+    round_id
+  FROM shots
+)
+
+SELECT
+  *
+FROM shots_with_row_number
+WHERE rn != hole_shot_seq


### PR DESCRIPTION
This PR adds logic to calculate the strokes gained value for each shot. The PGA TOUR benchmark is complete and the data is ready to be visualized!