### PR TITLE
Specifying package version

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: ">=0.7.3"
+    version: "0.7.6"


### PR DESCRIPTION
This change specifies the package version for `dbt_utils`. The most recent package version is incompatible with `dbt v0.21.0`, which is the current version. Eventually I need to upgrade to `dbt 1.0.x` and then we can simultaneously upgrade `dbt_utils` to `8.0`.